### PR TITLE
Multiple life totals

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,7 +119,6 @@ def start_game(lcds, buttons, p1_hp, p2_hp):
     game_loop(lcds, buttons, p1_hp, p2_hp)
 
 def game_loop(lcds, buttons, p1_hp, p2_hp):
-
     while running:
         change_hp(buttons, p1_hp, p2_hp)
         game_over(lcds, p1_hp, p2_hp)

--- a/main.py
+++ b/main.py
@@ -10,17 +10,13 @@ from machine import I2C, Pin
 import time
 from pico_i2c_lcd import I2cLcd
 
-# Set base hp values
-p1_hp = 40
-p2_hp = 40
-
 # Empty array to hold LCD displays
 lcds = []
 
 # Empty array to hold buttons
 buttons = []
 
-
+running = False
 
 def set_up_lcds(lcds): # Find and set LCD display addresses    
     i2c_1 = I2C(0, sda=Pin(0), scl=Pin(1), freq=400000)
@@ -47,6 +43,24 @@ def set_up_buttons(buttons):
     
     return buttons
 
+def set_starting_hp(lcds, buttons):
+    lcds[0].putstr('Starting life?')
+    lcds[0].move_to(0,1)
+    lcds[0].putstr ("20 40")
+    lcds[1].putstr('Waiting for')
+    lcds[1].move_to(0,1)
+    lcds[1].putstr('Player 1')
+    
+    selecting = True
+    while selecting:
+        if(buttons[0].value()) == 0:
+           p1_hp = 20
+           p2_hp = 20
+           start_game(lcds, buttons, p1_hp, p2_hp)
+        elif(buttons[1].value()) == 0:
+            p1_hp = 40
+            p2_hp = 40
+            start_game(lcds, buttons, p1_hp, p2_hp)
 
 def display_version():
     for lcd in lcds:
@@ -77,21 +91,35 @@ def update_hp_display(p1_hp, p2_hp):
         
         
 
-def change_hp(buttons):
-    global p1_hp, p2_hp
-    
-    if(buttons[0].value() == 0):
+def change_hp(buttons, p1_hp, p2_hp): 
+    if(buttons[0].value()) == 0:
         p1_hp += 1
         update_hp_display(p1_hp, p2_hp)
-    elif(buttons[1].value() == 0):
+        return(p1_hp, p2_hp)
+    elif(buttons[1].value()) == 0:
         p1_hp -= 1
         update_hp_display(p1_hp, p2_hp)
-    elif(buttons[2].value() == 0):
+        return(p1_hp, p2_hp)
+    elif(buttons[2].value()) == 0:
         p2_hp += 1
         update_hp_display(p1_hp, p2_hp)
-    elif(buttons[3].value() ==0):
+        return(p1_hp, p2_hp)
+    elif(buttons[3].value()) == 0:
         p2_hp -= 1
         update_hp_display(p1_hp, p2_hp)
+        return(p1_hp, p2_hp)
+    
+       
+def start_game(lcds, buttons, p1_hp, p2_hp):
+    global selecting
+    global running
+    selecting = False
+    init_display_hp(p1_hp, p2_hp)
+    
+    running = True
+    while running:
+        change_hp(buttons, p1_hp, p2_hp)
+        game_over(lcds, p1_hp, p2_hp)
 
 
 def game_over(lcds, p1_hp, p2_hp):
@@ -116,10 +144,6 @@ def game_over(lcds, p1_hp, p2_hp):
 set_up_lcds(lcds)
 set_up_buttons(buttons)
 display_version()
-init_display_hp(p1_hp, p2_hp)
+set_starting_hp(lcds, buttons)
 
-
-while True:
-    change_hp(buttons)
-    game_over(lcds, p1_hp, p2_hp)
  

--- a/main.py
+++ b/main.py
@@ -95,19 +95,19 @@ def change_hp(buttons, p1_hp, p2_hp):
     if(buttons[0].value()) == 0:
         p1_hp += 1
         update_hp_display(p1_hp, p2_hp)
-        return(p1_hp, p2_hp)
+        game_loop(p1_hp, p2_hp)
     elif(buttons[1].value()) == 0:
         p1_hp -= 1
         update_hp_display(p1_hp, p2_hp)
-        return(p1_hp, p2_hp)
+        game_loop(p1_hp, p2_hp)
     elif(buttons[2].value()) == 0:
         p2_hp += 1
         update_hp_display(p1_hp, p2_hp)
-        return(p1_hp, p2_hp)
+        game_loop(p1_hp, p2_hp)
     elif(buttons[3].value()) == 0:
         p2_hp -= 1
         update_hp_display(p1_hp, p2_hp)
-        return(p1_hp, p2_hp)
+        game_loop(p1_hp, p2_hp)
     
        
 def start_game(lcds, buttons, p1_hp, p2_hp):
@@ -116,9 +116,11 @@ def start_game(lcds, buttons, p1_hp, p2_hp):
     global running
     running = True
     init_display_hp(p1_hp, p2_hp)
-    game_loop(lcds, buttons, p1_hp, p2_hp)
+    game_loop(p1_hp, p2_hp)
 
-def game_loop(lcds, buttons, p1_hp, p2_hp):
+def game_loop(p1_hp, p2_hp):
+    global lcds
+    global buttons
     while running:
         change_hp(buttons, p1_hp, p2_hp)
         game_over(lcds, p1_hp, p2_hp)

--- a/main.py
+++ b/main.py
@@ -112,11 +112,14 @@ def change_hp(buttons, p1_hp, p2_hp):
        
 def start_game(lcds, buttons, p1_hp, p2_hp):
     global selecting
-    global running
     selecting = False
-    init_display_hp(p1_hp, p2_hp)
-    
+    global running
     running = True
+    init_display_hp(p1_hp, p2_hp)
+    game_loop(lcds, buttons, p1_hp, p2_hp)
+
+def game_loop(lcds, buttons, p1_hp, p2_hp):
+
     while running:
         change_hp(buttons, p1_hp, p2_hp)
         game_over(lcds, p1_hp, p2_hp)

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@
 # CURRENT FEATURES ARE ABILITY TO RAISE AND LOWER HP VALUES
 # WHEN HP REACHES 0, DISPLAY GAME OVER MESSAGE
 
-# TODO: ADD ABILITY TO CHANGE STARTING LIFE BETWEEN 20 AND 40
+# TODO: ADD RESTART GAME FUNCTIONALITY
 
 
 from machine import I2C, Pin
@@ -88,27 +88,7 @@ def update_hp_display(p1_hp, p2_hp):
     for lcd in lcds:
         display_hp(lcd, p1_hp, p2_hp)
     time.sleep(0.5)
-        
-        
 
-def change_hp(buttons, p1_hp, p2_hp): 
-    if(buttons[0].value()) == 0:
-        p1_hp += 1
-        update_hp_display(p1_hp, p2_hp)
-        game_loop(p1_hp, p2_hp)
-    elif(buttons[1].value()) == 0:
-        p1_hp -= 1
-        update_hp_display(p1_hp, p2_hp)
-        game_loop(p1_hp, p2_hp)
-    elif(buttons[2].value()) == 0:
-        p2_hp += 1
-        update_hp_display(p1_hp, p2_hp)
-        game_loop(p1_hp, p2_hp)
-    elif(buttons[3].value()) == 0:
-        p2_hp -= 1
-        update_hp_display(p1_hp, p2_hp)
-        game_loop(p1_hp, p2_hp)
-    
        
 def start_game(lcds, buttons, p1_hp, p2_hp):
     global selecting
@@ -122,7 +102,18 @@ def game_loop(p1_hp, p2_hp):
     global lcds
     global buttons
     while running:
-        change_hp(buttons, p1_hp, p2_hp)
+        if(buttons[0].value()) == 0:
+            p1_hp += 1
+            update_hp_display(p1_hp, p2_hp)
+        elif(buttons[1].value()) == 0:
+            p1_hp -= 1
+            update_hp_display(p1_hp, p2_hp)
+        elif(buttons[2].value()) == 0:
+            p2_hp += 1
+            update_hp_display(p1_hp, p2_hp)
+        elif(buttons[3].value()) == 0:
+            p2_hp -= 1
+            update_hp_display(p1_hp, p2_hp)
         game_over(lcds, p1_hp, p2_hp)
 
 


### PR DESCRIPTION
Added functionality to switch between 20 and 40 life. LifeDeck should now work for all standard MTG games.